### PR TITLE
docs: fix inaccurate claims and update completion status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/tower-rate-tier.svg)](https://crates.io/crates/tower-rate-tier)
 [![Documentation](https://docs.rs/tower-rate-tier/badge.svg)](https://docs.rs/tower-rate-tier)
-[![License](https://img.shields.io/crates/l/tower-rate-tier.svg)](LICENSE)
+[![License](https://img.shields.io/crates/l/tower-rate-tier.svg)](LICENSE-MIT)
 
 Every SaaS API needs rate limiting by user plan (free/pro/enterprise). `tower-rate-tier` eliminates the 200-400 lines of custom middleware you'd otherwise write.
 
@@ -14,7 +14,7 @@ Every SaaS API needs rate limiting by user plan (free/pro/enterprise). `tower-ra
 - **Request cost/weight** — Expensive endpoints consume more quota (`/export` = 20, `/search` = 5)
 - **Async identifier** — Extract `(user_id, tier)` from headers, JWT, API keys, or request body
 - **GCRA algorithm** — Smooth rate enforcement, no burst-at-boundary issues (used by Stripe, GitHub, Shopify)
-- **Pluggable storage** — In-memory (DashMap) or Redis for distributed setups
+- **Pluggable storage** — In-memory (DashMap) with automatic GC, Redis planned for v0.2
 - **Testable clock** — Deterministic time control in tests with `FakeClock`
 - **Standard headers** — `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`, `Retry-After`
 - **Tower-native** — Works with Axum, Tonic, Hyper, or any Tower-based framework
@@ -105,12 +105,11 @@ Content-Type: application/json
 ## Optional Features
 
 ```toml
-# Redis support for distributed rate limiting
-tower-rate-tier = { version = "0.1", features = ["redis"] }
-
 # Body-based identification (opt-in, buffers request body)
 tower-rate-tier = { version = "0.1", features = ["buffered-body"] }
 ```
+
+> Redis support for distributed rate limiting is planned for v0.2.
 
 ## Testing
 
@@ -149,7 +148,7 @@ let tier = RateTier::builder()
 
 ## Storage Error Behavior
 
-When Redis is unavailable:
+Configure behavior when the storage backend fails:
 
 ```rust
 let layer = TierLimitLayer::new(tier)
@@ -165,7 +164,7 @@ let layer = TierLimitLayer::new(tier)
 | Request cost/weight | No | No | No | **Yes** |
 | Async identifier | No | Partial | No | **Yes** |
 | Body-based identification | No | No | No | **Yes** |
-| Distributed (Redis) | No | No | No | **Yes** |
+| Distributed (Redis) | No | No | No | **Planned v0.2** |
 | Testable clock | No | Yes | No | **Yes** |
 | Tower-compatible | Yes | Axum only | Axum only | **Yes** |
 | Algorithm | GCRA | Token bucket | GCRA | **GCRA** |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -6,19 +6,21 @@
 
 Core library with in-memory storage and full Tower integration.
 
-- [ ] Core types: `RateTier`, `RateTierBuilder`, `Quota`, `TierIdentity`
-- [ ] GCRA algorithm implementation
-- [ ] `TierLimitLayer` / `TierLimitService` (Tower Layer + Service)
-- [ ] `TierIdentifier` trait + closure adapter (`identifier_fn`)
-- [ ] `tier_cost()` layer for per-endpoint request weighting
-- [ ] `OnMissing` behavior: `UseDefault`, `Allow`, `Deny(StatusCode)`
-- [ ] In-memory storage with `DashMap` + automatic GC of expired keys
-- [ ] Standard rate limit headers (`X-RateLimit-Limit`, `Remaining`, `Reset`, `Retry-After`)
-- [ ] 429 JSON response body
-- [ ] `FakeClock` for deterministic testing
-- [ ] Body-based identification (feature-gated: `buffered-body`)
-- [ ] Examples: `axum_basic`, `axum_jwt`
-- [ ] README with usage guide
+- [x] Core types: `RateTier`, `RateTierBuilder`, `Quota`, `TierIdentity`
+- [x] GCRA algorithm implementation
+- [x] `TierLimitLayer` / `TierLimitService` (Tower Layer + Service)
+- [x] `TierIdentifier` trait + closure adapter (`identifier_fn`)
+- [x] `tier_cost()` layer for per-endpoint request weighting
+- [x] `OnMissing` behavior: `UseDefault`, `Allow`, `Deny(StatusCode)`
+- [x] `OnStorageError` behavior: `Allow` (fail open) / `Deny` (fail closed)
+- [x] `StorageError` type for distinguishing backend failures from rate limits
+- [x] In-memory storage with `DashMap` + automatic GC of expired keys
+- [x] Standard rate limit headers (`X-RateLimit-Limit`, `Remaining`, `Reset`, `Retry-After`)
+- [x] 429 JSON response body
+- [x] `FakeClock` for deterministic testing
+- [x] Body-based identification (feature-gated: `buffered-body`)
+- [x] Examples: `axum_basic`, `axum_jwt`
+- [x] README with usage guide
 - [ ] Published to crates.io
 
 ## v0.2.0 — Distributed & Observability
@@ -27,7 +29,6 @@ Redis storage and monitoring hooks.
 
 - [ ] Redis storage backend (feature-gated: `redis`)
 - [ ] Atomic GCRA via Lua script (race-condition-free)
-- [ ] `OnStorageError` behavior: `Allow` (fail open) / `Deny` (fail closed)
 - [ ] `on_limited` callback for metrics/events
 - [ ] Custom 429 response body builder
 - [ ] Example: `axum_api_key` with Redis tier lookup

--- a/docs/roadmap/design/2026-03-11-tower-rate-tier-design.md
+++ b/docs/roadmap/design/2026-03-11-tower-rate-tier-design.md
@@ -383,18 +383,18 @@ optional = true
 ## 7. Success Criteria
 
 ### v0.1.0 (MVP)
-- [ ] Core: RateTier builder, Quota, GCRA
-- [ ] Tower Layer/Service implementation
-- [ ] Async identifier with closure support
-- [ ] In-memory storage with DashMap + GC
-- [ ] Request cost/weight layer
-- [ ] OnMissing behavior
-- [ ] Standard rate limit headers
-- [ ] 429 response with JSON body
-- [ ] FakeClock for testing
-- [ ] Body access in identifier (feature-gated `buffered-body`)
-- [ ] Examples: axum_basic, axum_jwt
-- [ ] README with usage guide
+- [x] Core: RateTier builder, Quota, GCRA
+- [x] Tower Layer/Service implementation
+- [x] Async identifier with closure support
+- [x] In-memory storage with DashMap + GC
+- [x] Request cost/weight layer
+- [x] OnMissing behavior
+- [x] Standard rate limit headers
+- [x] 429 response with JSON body
+- [x] FakeClock for testing
+- [x] Body access in identifier (feature-gated `buffered-body`)
+- [x] Examples: axum_basic, axum_jwt
+- [x] README with usage guide
 - [ ] Published to crates.io
 
 ### v0.2.0


### PR DESCRIPTION
## Summary
- Remove misleading Redis references from README (Redis is v0.2, not v0.1)
- Fix LICENSE badge link (was pointing to nonexistent `LICENSE` file)
- Mark all completed v0.1.0 items as `[x]` in roadmap and design doc
- Add `OnStorageError` and `StorageError` to roadmap (already implemented)
- Clarify storage error section language (not Redis-specific)

## Test plan
- [x] Documentation-only changes, no code affected
- [x] 87 tests still passing